### PR TITLE
reduce batch size to prevent error

### DIFF
--- a/config/main.sample.yaml
+++ b/config/main.sample.yaml
@@ -9,7 +9,7 @@ deepCheck:
   enabled: false
 claim:
   enabled: false
-  batchSize: 9
+  batchSize: 5
   gracePeriod:
     enabled: false
     eras: 4


### PR DESCRIPTION
Reducing batch size fixes the following error:

```
error: Could not perform one of the claims: RpcError: 1010: Invalid Transaction: Transaction would exhaust the block limits
RPC-CORE: submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1010: Invalid Transaction: Transaction would exhaust the block limits
```