### PR TITLE
add filterByTag functionality

### DIFF
--- a/charts/polkadot-k8s-payouts/Chart.yaml
+++ b/charts/polkadot-k8s-payouts/Chart.yaml
@@ -1,5 +1,5 @@
 description: Polkadot K8s Payouts
 name: polkadot-k8s-payouts
-version: v1.3.5
-appVersion: v1.3.5
+version: v1.4.0
+appVersion: v1.4.0
 apiVersion: v2

--- a/charts/polkadot-k8s-payouts/values.yaml
+++ b/charts/polkadot-k8s-payouts/values.yaml
@@ -23,6 +23,8 @@ config:
     userId: "@bot:matrix.org"
     room: "!xxx:matrix.org"
     notifyRestarts: false
+  filterByTag:
+    enabled: false  
   targets: [] #optional
   deepCheck: 
     enabled: false

--- a/config/main.sample.yaml
+++ b/config/main.sample.yaml
@@ -22,9 +22,13 @@ matrix: #optional
   userId: "@bot:matrix.org"
   room: "!xxx:matrix.org"
   notifyRestarts: false
+filterByTag: #optional
+  enabled: true
+  tag: "group1"
 targets: #optional  
 - alias: validator-000
-    validatorAddress: "<validator-000-stash-address>"
+  validatorAddress: "<validator-000-stash-address>"
+  tag: "group1"
 - alias: validator-001
   validatorAddress: "<validator-001-stash-address>"
 deepCheck:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polkadot-payouts",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "Automated transfers among accounts",
   "repository": "git@github.com:w3f/accountant.git",
   "author": "W3F Infrastructure Team <devops@web3.foundation>",

--- a/src/actions/start.ts
+++ b/src/actions/start.ts
@@ -23,7 +23,9 @@ const _loadConfig = async (config: any): Promise<InputConfig> =>{
     const filteredArr = [...cfg.targets,...gitTargets].filter(el=>{ //priority given to locals over downloaded ones
         const isDuplicate = seen.has(el.alias);
         seen.add(el.alias)
-        return !isDuplicate
+
+        const isTagMatch =  (!cfg.filterByTag?.enabled) || (el.tag && cfg.filterByTag.tag == el.tag)
+        return !isDuplicate && isTagMatch
     })
     cfg.targets = filteredArr
     return cfg

--- a/src/gitConfigLoader/gitLabPrivate.ts
+++ b/src/gitConfigLoader/gitLabPrivate.ts
@@ -56,7 +56,8 @@ export class GitLabPrivate implements GitConfigLoader {
     return tmp.map(t=>{
       const target: Target = {
         alias: t.name,
-        validatorAddress: t.address
+        validatorAddress: t.address,
+        tag: t.tag
       } 
       return target
     })

--- a/src/gitConfigLoader/types.ts
+++ b/src/gitConfigLoader/types.ts
@@ -9,6 +9,7 @@ export interface TargetFromGit1kv {
 export interface GitLabTarget {
   name: string;
   address: string;
+  tag?: string; 
 }
 
 export interface InputConfigFromGitLabPrivate {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,10 +8,15 @@ export interface Keystore {
 export interface Target {
   alias: string;
   validatorAddress: string;
+  tag?: string;
 }
 
 export interface ClaimerInputConfig {
     targets?: Array<Target>;
+    filterByTag?: {
+      enabled: boolean;
+      tag?: string;
+    };
     deepCheck: {
       enabled: boolean;
     };


### PR DESCRIPTION
single config file, capability to filter out targets based on a tag => possibility to define multiple groups in the same file

Possible use case: different claimer instances for different groups (different claimer wallets)